### PR TITLE
Allows Gedit to show the Close button at the left when the left panel…

### DIFF
--- a/gedit/gedit-window.c
+++ b/gedit/gedit-window.c
@@ -2369,15 +2369,15 @@ side_panel_visibility_changed (GtkWidget   *panel,
 		if (tokens)
 		{
 			gchar *layout_headerbar;
-			gchar *layout_headerbar2;
+			gchar *layout_side_headerbar;
 
 			layout_headerbar = g_strdup_printf ("%c%s", ':', tokens[1]);
-			layout_headerbar2 = g_strdup_printf ("%s%c",  tokens[0], ':');
+			layout_side_headerbar = g_strdup_printf ("%s%c",  tokens[0], ':');
 			gtk_header_bar_set_decoration_layout (GTK_HEADER_BAR (window->priv->headerbar), layout_headerbar);
-			gtk_header_bar_set_decoration_layout (GTK_HEADER_BAR (window->priv->side_headerbar), layout_headerbar2);
+			gtk_header_bar_set_decoration_layout (GTK_HEADER_BAR (window->priv->side_headerbar), layout_side_headerbar);
 
 			g_free (layout_headerbar);
-			g_free (layout_headerbar2);
+			g_free (layout_side_headerbar);
 			g_strfreev (tokens);
 		}
 	}

--- a/gedit/gedit-window.c
+++ b/gedit/gedit-window.c
@@ -2369,12 +2369,15 @@ side_panel_visibility_changed (GtkWidget   *panel,
 		if (tokens)
 		{
 			gchar *layout_headerbar;
+			gchar *layout_headerbar2;
 
 			layout_headerbar = g_strdup_printf ("%c%s", ':', tokens[1]);
+			layout_headerbar2 = g_strdup_printf ("%s%c",  tokens[0], ':');
 			gtk_header_bar_set_decoration_layout (GTK_HEADER_BAR (window->priv->headerbar), layout_headerbar);
-			gtk_header_bar_set_decoration_layout (GTK_HEADER_BAR (window->priv->side_headerbar), tokens[0]);
+			gtk_header_bar_set_decoration_layout (GTK_HEADER_BAR (window->priv->side_headerbar), layout_headerbar2);
 
 			g_free (layout_headerbar);
+			g_free (layout_headerbar2);
 			g_strfreev (tokens);
 		}
 	}

--- a/gedit/resources/ui/gedit-window.ui
+++ b/gedit/resources/ui/gedit-window.ui
@@ -16,6 +16,7 @@
           <object class="GtkHeaderBar" id="side_headerbar">
             <property name="visible" bind-source="side_panel" bind-property="visible" bind-flags="sync-create"/>
             <property name="title" translatable="yes">Documents</property>
+            <property name="show_close_button">True</property>
             <style>
               <class name="gedit-titlebar-left"/>
               <class name="titlebar"/>


### PR DESCRIPTION
… when the left panel is visible. Fixes bug 745381. Of course, when the user wants the close button at the right, it works fine (tested).