### PR TITLE
fixed pyGI import + new url for fpaste

### DIFF
--- a/plugins/externaltools/data/send-to-fpaste.tool.in
+++ b/plugins/externaltools/data/send-to-fpaste.tool.in
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import os, urllib, json, sys, urllib.request
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk
 
 text = sys.stdin.read()
@@ -10,7 +12,7 @@ if lang is None:
     lang = "text"
 
 url_params = urllib.parse.urlencode({'paste_data': text, 'paste_lang': lang, 'mode':'json', 'api_submit':'true'})
-openfpaste = urllib.request.urlopen("http://fpaste.org", bytes(url_params, 'utf-8')).read().decode("utf-8")
+openfpaste = urllib.request.urlopen("http://paste.fedoraproject.org", bytes(url_params, 'utf-8')).read().decode("utf-8")
 if openfpaste is None:
     print("Failed to send fpaste request.")
 


### PR DESCRIPTION
"PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded."